### PR TITLE
change visibility on ParseTree element in order to use the name and text

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Now the library has experimental status and isn't published in the maven.
 
 ## Using
 
-To use the library you can run the `publishToMavenLocal` gradle task and add `mavenLocal` to repositories in your program, and then add dependency from this library. For example (gradle): `compile("org.jetbrains.kotlin:kotlin-grammar-tools:0.1")`.
+To use the library you can run the `publishToMavenLocal` gradle task and add `mavenLocal` to repositories in your program, and then add dependency from this library. For example (gradle): `compile("org.jetbrains.kotlin.spec.grammar.tools:kotlin-grammar-tools:0.1")`.
 
 Also, you can just download jar from [Releases](https://github.com/Kotlin/kotlin-grammar-tools/releases) or TeamCity (`kotlin-grammar-tools` artifacts can be found on the [TeamCity Kotlin grammar builds pages](https://teamcity.jetbrains.com/viewType.html?buildTypeId=Kotlin_Spec_GrammarMaster)).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,8 +12,8 @@ val archivePrefix = "kotlin-grammar-tools"
 val jar: Jar by tasks
 
 repositories {
-    mavenCentral()
     mavenLocal()
+    mavenCentral()
 }
 
 dependencies {

--- a/src/main/kotlin/org/jetbrains/kotlin/spec/grammar/tools/KotlinGrammarTools.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/spec/grammar/tools/KotlinGrammarTools.kt
@@ -32,8 +32,8 @@ class KotlinParserException(val parserMessage: String, val position: Pair<Int, I
 
 class KotlinParseTree(
     val type: KotlinParseTreeNodeType,
-    private val name: String,
-    private val text: String? = null,
+    val name: String,
+    val text: String? = null,
     val children: MutableList<KotlinParseTree> = mutableListOf()
 ) {
     companion object {


### PR DESCRIPTION
Fixed maven group in the documentation.

Changed visibility on `name` and `text` in `KotlinParseTree` I could figure out another way to get the actual values.