### PR TITLE
Up kotlin and gradle versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.3.11"
+    kotlin("jvm") version "1.4.31"
     `maven-publish`
 }
 
@@ -47,4 +47,4 @@ jar.manifest {
     )
 }
 
-jar.from(configurations.runtime.map { if (it.isDirectory) it else zipTree(it) })
+jar.from(configurations.runtime.files.map { if (it.isDirectory) it else zipTree(it) })

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updating spec gradle & kotlin plugin versions magically breaks grammar tools with cryptic errors: https://teamcity.jetbrains.com/viewLog.html?buildId=3386370&buildTypeId=Kotlin_Spec_AggregateBuildsMaster

This, in turn, breaks spec CI. The easiest way around this (without delving into the abyss that this errors are) is update the versions in grammar-tools accordingly.